### PR TITLE
fix: max number JS issue

### DIFF
--- a/lib/digit_to_word.dart
+++ b/lib/digit_to_word.dart
@@ -44,9 +44,10 @@ class DigitToWord {
   /// [withDashes] is an optional boolen parameter that will prevent `-` being added between the tens and ones places.
   static String translate(int number, {bool withDashes = true}) {
     if (withDashes == false) _useDash = false;
-    final isOutOfBounds = number.abs() > 9223372036854775807 ? true : false;
+    final maxNumber = double.maxFinite.toInt();
+    final isOutOfBounds = number.abs() > maxNumber ? true : false;
     if (isOutOfBounds) {
-      return 'Number has to be between -9223372036854775807 and 9223372036854775807';
+      return 'Number has to be between -$maxNumber and $maxNumber';
     }
     if (number == 0) {
       return 'zero';


### PR DESCRIPTION
When trying to run integration tests in a browser (https://flutter.dev/docs/testing/integration-tests), `flutter driver` produces a following error:

> /home/robert/.pub-cache/hosted/pub.dartlang.org/digit_to_word-1.2.0/lib/digit_to_word.dart:47:42: Error: The integer literal 9223372036854775807 can't be represented exactly in JavaScript.
> Try changing the literal to something that can be represented in Javascript. In Javascript 9223372036854775808 is the nearest value that can be represented exactly.
>     final isOutOfBounds = number.abs() > 9223372036854775807 ? true : false;

This PR fixes this issue.